### PR TITLE
R7 en MUL activado por defecto

### DIFF
--- a/src/qweb/config.json
+++ b/src/qweb/config.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "registers_number": 8,
-  "mul_modifies_r7": false,
+  "mul_modifies_r7": true,
   "default_value": {
     "cells": "zero",
     "registers": "zero"

--- a/src/ui/ConfigForm.js
+++ b/src/ui/ConfigForm.js
@@ -210,15 +210,6 @@ export default function ConfigForm({ open, setOpen }) {
           <CloseIcon />
         </IconButton>
         <DialogContent>
-
-          <FormControl component="fieldset" className={classes.margin}>
-            <FormLabel component="legend" className={classes.marginBaby}>MUL modifica el registro R7:</FormLabel>
-            <FormControlLabel
-              labelPlacement="top"
-              id="mul_modifies_r7"
-              control={<Switch checked={mulModifiesR7} onChange={mulModifiesR7HandleChange} size="medium" name="mulModifiesR7" color="primary" />}
-            />
-          </FormControl>
           <FormControl component="fieldset" className={classes.margin}>
             <FormLabel component="legend" >Cantidad de registros:</FormLabel><br/>
             <Slider


### PR DESCRIPTION
## Feature implementada

Ahora por defecto el MUL modifica tanto el destino como R7, como se ve en la arquitectura Q.
Además, se quito la posibilidad de activar o desactivar esta opción.

[US en Trello](https://trello.com/c/pLRs0v4Y/4-quitar-opción-de-modificar-mul)