### PR TITLE
Se deshabilito la configuracion de instrucciones

### DIFF
--- a/src/ui/ConfigForm.js
+++ b/src/ui/ConfigForm.js
@@ -162,6 +162,7 @@ export default function ConfigForm({ open, setOpen }) {
         id={id}
         checked={enabled}
         color="primary"
+        disabled={true}
         onChange={instructionHandleChange}
         name={id} />}
       label={label}


### PR DESCRIPTION
Ya no se puede modificar las instrucciones habilitadas en el simulador.
Se visualizan todas las activas.

[US en Trello](https://trello.com/c/1BjhY59C/11-eliminar-configuraci%C3%B3n-de-instrucciones)