### PR TITLE
Listar el total de errores del editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.3.2",
         "@testing-library/user-event": "^7.1.2",
-        "ace-builds": "^1.4.11",
+        "ace-builds": "^1.36.2",
         "file-saver": "^2.0.2",
         "nearley": "git+https://gitlab.com/qweb-project/nearley-qweb.git",
         "notistack": "^0.9.16",
@@ -6173,9 +6173,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.11.tgz",
-      "integrity": "sha512-keACH1d7MvAh72fE/us36WQzOFQPJbHphNpj33pXwVZOM84pTWcdFzIAvngxOGIGLTm7gtUP2eJ4Ku6VaPo8bw=="
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.2.tgz",
+      "integrity": "sha512-eqqfbGwx/GKjM/EnFu4QtQ+d2NNBu84MGgxoG8R5iyFpcVeQ4p9YlTL+ZzdEJqhdkASqoqOxCSNNGyB6lvMm+A=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "ace-builds": "^1.4.11",
+    "ace-builds": "^1.36.2",
     "file-saver": "^2.0.2",
     "nearley": "git+https://gitlab.com/qweb-project/nearley-qweb.git",
     "notistack": "^0.9.16",

--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,17 @@
     transform: rotate(360deg);
   }
 }
+
+.error-highlight {
+  position: relative;
+  border-bottom: 1px solid red;
+}
+.wavy-underline {
+  position: relative;
+  border-bottom: 2px solid red; 
+  border-bottom-style: wavy;
+  text-decoration-style: wavy;
+  text-decoration-line: underline; 
+  text-decoration-color: red;
+  /* Cambia el color según tu necesidad */
+}

--- a/src/App.css
+++ b/src/App.css
@@ -38,7 +38,7 @@
 }
 
 .error-highlight {
-  position: relative;
+  position: absolute;
   border-bottom: 1px solid red;
 }
 .wavy-underline {

--- a/src/App.css
+++ b/src/App.css
@@ -41,12 +41,3 @@
   position: absolute;
   border-bottom: 1px solid red;
 }
-.wavy-underline {
-  position: relative;
-  border-bottom: 2px solid red; 
-  border-bottom-style: wavy;
-  text-decoration-style: wavy;
-  text-decoration-line: underline; 
-  text-decoration-color: red;
-  /* Cambia el color según tu necesidad */
-}

--- a/src/arch-views/CodeExecutor.js
+++ b/src/arch-views/CodeExecutor.js
@@ -92,8 +92,6 @@ export default function CodeExecutor() {
   const actionMode = qConfig.getItem('actions_mode')
   const CurrentActionMode = useMemo(() => ActionMode.find_modeclass(actionMode), [actionMode])
   const [currentExecutionMode, setCurrentExecutionMode] = useState(EXECUTION_MODE_NORMAL)
-  const [lastStartRow, setLastStartRow] = useState(0);
-  const lastErrorIndexRef = useRef(-1);
 
   function load_program(routines) {
     computer.load_many(routines)
@@ -153,14 +151,13 @@ export default function CodeExecutor() {
       addErrors(errors)
       const hasErrors = errors.some(e => e && e.error);
       
-      console.log(aceEditorMarkers)
       if(!hasErrors) {
         return routines
       }
     }
     catch (e) {
-      addError(e)
-      setResult(e.message)
+      //addError(e)
+      //setResult(e.message)
     }
   }
   function addErrors(errors) {
@@ -168,7 +165,7 @@ export default function CodeExecutor() {
     const { result } = errors.reduce((acc, e) => {
       const { result } = acc;
   
-      const newResult = e && e.error ? `${result}\n${e.error.message}` : result;
+      const newResult = `${result}\n${e.error.message}`
       
       addError(e, session);
   

--- a/src/arch-views/CodeExecutor.js
+++ b/src/arch-views/CodeExecutor.js
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
     flexGrow: 1,
   },
   results: {
-    fontFamily: 'mono'
+    fontFamily: 'monospace'
   },
   fab: (isMobile ? {
     position: 'absolute',

--- a/src/arch-views/CodeExecutor.js
+++ b/src/arch-views/CodeExecutor.js
@@ -144,16 +144,27 @@ export default function CodeExecutor() {
   function parse_code(codeToParse) {
     try {
       setAceEditorErrors([])
-      const parsed_code = parser.parse_code(codeToParse)
-      setResult('')
-      return parsed_code
+      let result = ''
+      const { routines, errors } = parser.parse_code(codeToParse)
+      if (errors.length > 0) {
+        errors.forEach(e => {addError(e.error)
+        result += `\n${e.error.message}`})
+      }
+      setResult(result)
+      return routines
     }
     catch (e) {
-      setAceEditorErrors([{ row: e.line, column: Math.random(), type: 'error', text: e.shorterMessage }])
+      addError(e)
       setResult(e.message)
     }
   }
 
+  const addError = (e) => {
+    setAceEditorErrors(prevErrors => [
+      ...prevErrors,
+      { row: e.line, column: Math.random(), type: 'error', text: e.shorterMessage }
+    ]);
+  };
   function execute_cycle() {
     try {
       switchDetailedMode(EXECUTION_MODE_ONE_INSTRUCTION)

--- a/src/qweb/language/parser.js
+++ b/src/qweb/language/parser.js
@@ -38,11 +38,11 @@ class Parser {
         if (parsed_instruction.instruction.assembleIn) {
           assembly_cell = parsed_instruction.instruction.assembleIn.value.slice(2)
           routines.push(new Routine(assembly_cell))
-          errors.push(null)
+          //errors.push(null)
         }
         else {
           routines[routines.length - 1].add_instruction(parsed_instruction)
-          errors.push(null)
+          //errors.push(null)
         }
       }
       catch (error) {

--- a/src/qweb/language/parser.js
+++ b/src/qweb/language/parser.js
@@ -38,11 +38,9 @@ class Parser {
         if (parsed_instruction.instruction.assembleIn) {
           assembly_cell = parsed_instruction.instruction.assembleIn.value.slice(2)
           routines.push(new Routine(assembly_cell))
-          //errors.push(null)
         }
         else {
           routines[routines.length - 1].add_instruction(parsed_instruction)
-          //errors.push(null)
         }
       }
       catch (error) {

--- a/src/qweb/language/parser.js
+++ b/src/qweb/language/parser.js
@@ -26,21 +26,28 @@ class Parser {
 
   parse_code(codeToParse) {
     let assembly_cell = '0000'
+    let errors = []
     //TODO: agregar un chequeo de que si codeToParse es '' lance una Exception 
     //
     return codeToParse.split(/\r\n|\r|\n/).reduce((routines, line, index) => {
       line = line.includes('#') ? line.slice(0, line.indexOf('#')) : line //Delete comments
       
       if (!line) return routines
-      const parsed_instruction = this.parse_line(line, index)
-      if (parsed_instruction.instruction.assembleIn) {
-        assembly_cell = parsed_instruction.instruction.assembleIn.value.slice(2)
-        routines.push(new Routine(assembly_cell))
+      try {
+        const parsed_instruction = this.parse_line(line, index)
+        if (parsed_instruction.instruction.assembleIn) {
+          assembly_cell = parsed_instruction.instruction.assembleIn.value.slice(2)
+          routines.push(new Routine(assembly_cell))
+        }
+        else {
+          routines[routines.length - 1].add_instruction(parsed_instruction)
+        }
       }
-      else {
-        routines[routines.length - 1].add_instruction(parsed_instruction)
+      catch (error) {
+        errors.push({ error, line: index })
       }
-      return routines
+      
+      return { routines, errors }; 
     }, [new Routine(assembly_cell)])
   }
 

--- a/src/qweb/language/parser.js
+++ b/src/qweb/language/parser.js
@@ -26,21 +26,23 @@ class Parser {
 
   parse_code(codeToParse) {
     let assembly_cell = '0000'
-    let errors = []
     //TODO: agregar un chequeo de que si codeToParse es '' lance una Exception 
     //
-    return codeToParse.split(/\r\n|\r|\n/).reduce((routines, line, index) => {
+    return codeToParse.split(/\r\n|\r|\n/).reduce((acc, line, index) => {
+      let { routines, errors } = acc;
       line = line.includes('#') ? line.slice(0, line.indexOf('#')) : line //Delete comments
       
-      if (!line) return routines
+      if (!line) return acc
       try {
         const parsed_instruction = this.parse_line(line, index)
         if (parsed_instruction.instruction.assembleIn) {
           assembly_cell = parsed_instruction.instruction.assembleIn.value.slice(2)
           routines.push(new Routine(assembly_cell))
+          errors.push(null)
         }
         else {
           routines[routines.length - 1].add_instruction(parsed_instruction)
+          errors.push(null)
         }
       }
       catch (error) {
@@ -48,7 +50,7 @@ class Parser {
       }
       
       return { routines, errors }; 
-    }, [new Routine(assembly_cell)])
+    }, { routines: [new Routine(assembly_cell)], errors: [] })
   }
 
 }


### PR DESCRIPTION
[US en Trello](https://trello.com/c/47e5Qlz4/18-5-parser-listar-todos-los-errores-al-ejecutar)
- Al dar enter cada linea que tiene un error de sintaxis, se muestra del lado izquierdo de la instrucción una cruz
- Del lado derecho se muestra un listado con el mensaje de error con el número de linea y el offset
- Se subraya en rojo la parte que tiene un error
- La fuente de los errores es igual a la del resto del simulador (sin serif)